### PR TITLE
fix(readme) update build status badge

### DIFF
--- a/README.md
+++ b/README.md
@@ -1,7 +1,7 @@
 # ![logo](https://raw.githubusercontent.com/azerothcore/azerothcore.github.io/master/images/logo-github.png) AzerothCore
 ## mod-npc-codebox
 ### This is a module for [AzerothCore](http://www.azerothcore.org)
-- Latest build status with azerothcore: [![Build Status](https://travis-ci.org/azerothcore/mod-npc-codebox.svg?branch=master)](https://travis-ci.org/azerothcore/mod-npc-codebox)
+- Latest build status with azerothcore: [![Build Status](https://github.com/azerothcore/mod-npc-codebox/workflows/core-build/badge.svg?branch=master&event=push)](https://github.com/azerothcore/mod-npc-codebox)
 
 
 ## Description


### PR DESCRIPTION
This pr updates the build status badge to point to the github actions workflow instead of travis-ci.